### PR TITLE
Fix to issue reported from twitter user C__Kronenberg

### DIFF
--- a/stata/rdrobust.ado
+++ b/stata/rdrobust.ado
@@ -117,15 +117,15 @@ program define rdrobust, eclass
 	}
 	
 	**** DROP MISSINGS **********************************************
-	qui drop if `y'==. | `x'==.
-	if ("`fuzzy'"~="")   qui drop if `fuzzyvar'==.
-	if ("`cluster'"!="") qui drop if `clustvar'==.
+	qui drop if mi(`y') | mi(`x')
+	if ("`fuzzy'"~="")   qui drop if mi(`fuzzyvar')
+	if ("`cluster'"!="") qui drop if mi(`clustvar')
 	if ("`covs'"~="") {
 		qui ds `covs', alpha
 		local covs_list = r(varlist)
 		local ncovs: word count `covs_list'	
 		foreach z in `covs_list' {
-			qui drop if `z'==.
+			qui drop if mi(`z')
 		}
 	}		
 		


### PR DESCRIPTION
Error occurred when the user above had a value of `.a` in a variable.  The logic for dropping cases with missing values fails to test for any missing value and only specifically tests for the missing value `.`.  Using the `missing()` function instead of the equality should take care of the issue.